### PR TITLE
Adopt eslint-plugin-react-hooks 7 and fix new-rule violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-chai-friendly": "^1.0.1",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
         "flat": "^6.0.1",
         "i18next-parser": "^9.4.0",
@@ -142,6 +142,153 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -158,6 +305,30 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -183,6 +354,40 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5973,16 +6178,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/balanced-match": {
@@ -6701,6 +6913,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7111,6 +7333,23 @@
       "integrity": "sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -8171,6 +8410,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -13129,6 +13381,13 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -13166,6 +13425,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-chai-friendly": "^1.0.1",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
     "flat": "^6.0.1",
     "i18next-parser": "^9.4.0",

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -61,13 +61,14 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
   const [selectedLanguage, setSelectedLanguage] = useState(initialLang);
 
   useEffect(() => {
-    if (!languages.some(lang => lang.code === selectedLanguage)) {
-      setSelectedLanguage('en');
+    const isValid = languages.some(lang => lang.code === selectedLanguage);
+    const target = isValid ? selectedLanguage : 'en';
+    if (!isValid) {
       localStorage.setItem('selectedLanguage', 'en');
-      i18next.changeLanguage('en');
-    } else {
-      i18next.changeLanguage(selectedLanguage);
     }
+    // Changing the language emits `languageChanged`, which the listener below
+    // turns into the state update -- so we never setState directly here.
+    i18next.changeLanguage(target);
   }, [selectedLanguage]);
 
   useEffect(() => {

--- a/src/components/LifeAreaCard.tsx
+++ b/src/components/LifeAreaCard.tsx
@@ -66,9 +66,12 @@ const LifeAreaCard: React.FC<LifeAreaCardProps> = ({
   }, [editingDetailsInline]);
 
   // When this card enters edit mode, seed the local draft from the live area
-  // and open the desktop dialog. Resetting on the rising edge of `isEditing`
-  // keeps the draft truthful without clobbering in-progress typing.
-  useEffect(() => {
+  // and open the desktop dialog. Using the during-render "previous prop"
+  // pattern keeps the draft truthful on the rising edge of `isEditing` without
+  // an extra effect commit and without clobbering in-progress typing.
+  const [wasEditing, setWasEditing] = useState(isEditing);
+  if (isEditing !== wasEditing) {
+    setWasEditing(isEditing);
     if (isEditing) {
       setEditName(area.name);
       setEditDescription(area.description);
@@ -81,7 +84,7 @@ const LifeAreaCard: React.FC<LifeAreaCardProps> = ({
         setEditingDetailsInline(false);
       }
     }
-  }, [isEditing, isDesktop]);
+  }
 
   const buildUpdatedArea = (): LifeArea => ({
     ...area,

--- a/src/components/OnboardingTutorialWrapper.tsx
+++ b/src/components/OnboardingTutorialWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import OnboardingTutorial from './OnboardingTutorial';
 
 interface OnboardingTutorialWrapperProps {
@@ -13,15 +13,10 @@ interface OnboardingTutorialWrapperProps {
 const OnboardingTutorialWrapper: React.FC<OnboardingTutorialWrapperProps> = ({
   onPredefinedSelected,
 }) => {
-  const [showTutorial, setShowTutorial] = useState(false);
-
-  useEffect(() => {
-    // Check localStorage for a tutorial completed flag
-    const tutorialCompleted = localStorage.getItem('tutorialCompleted');
-    if (!tutorialCompleted) {
-      setShowTutorial(true);
-    }
-  }, []);
+  // Show the tutorial on first launch, i.e. until the completed flag is set.
+  const [showTutorial, setShowTutorial] = useState(
+    () => !localStorage.getItem('tutorialCompleted'),
+  );
 
   const handleTutorialComplete = () => {
     localStorage.setItem('tutorialCompleted', 'true');

--- a/src/components/RadarChart.tsx
+++ b/src/components/RadarChart.tsx
@@ -10,6 +10,7 @@ import {
   Legend,
 } from 'recharts';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 
 type CustomTickProps = {
   x?: number;
@@ -52,6 +53,65 @@ interface RadarChartProps {
   aspect?: number;
 }
 
+// Defined at module scope (not inside RadarChart) so they are stable component
+// identities. recharts clones these elements with the tick/tooltip props it
+// computes; the extra props below are supplied by RadarChart.
+const RadarTick = ({
+  x,
+  y,
+  textAnchor,
+  payload,
+  tickFontSize,
+  isMobile,
+}: CustomTickProps & { tickFontSize?: number; isMobile?: boolean }) => (
+  <text
+    x={x}
+    y={y}
+    textAnchor={textAnchor}
+    fill="var(--color-text)"
+    fontSize={tickFontSize}
+  >
+    <tspan x={x} dy={0}>
+      {isMobile ? '' : payload.value}
+    </tspan>
+  </text>
+);
+
+const RadarTooltip = ({
+  active,
+  payload,
+  label,
+  t,
+}: CustomTooltipProps & { t: TFunction }) => {
+  if (active && payload && payload.length) {
+    const dataPoint = payload[0].payload;
+    return (
+      <div
+        style={{
+          backgroundColor: 'var(--color-bg)',
+          border: `1px solid var(--border)`,
+          padding: 10,
+          color: 'var(--color-text)',
+        }}
+      >
+        <p>
+          <strong>{label}</strong>
+        </p>
+        <p>
+          {t('importance')}: {dataPoint.importance}
+        </p>
+        <p>
+          {t('lived_according_to_past_week')}: {dataPoint.satisfaction}
+        </p>
+        <p>
+          {t('description')}: {dataPoint.description}
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
 const RadarChart: React.FC<RadarChartProps> = ({
   data,
   width = '100%',
@@ -81,67 +141,6 @@ const RadarChart: React.FC<RadarChartProps> = ({
     return data;
   }, [data]);
 
-  const renderTick = (props: CustomTickProps) => {
-    const { payload, x, y, textAnchor } = props;
-    const value = payload.value;
-    const lines = [value];
-    /*if ((textAnchor === 'start' || textAnchor === 'end') && value.length > 10) {
-      const mid = Math.floor(value.length / 2);
-      let breakIndex = value.lastIndexOf(' ', mid);
-      if (breakIndex === -1) {
-        breakIndex = mid;
-      }
-      const firstLine = value.substring(0, breakIndex).trim();
-      const secondLine = value.substring(breakIndex).trim();
-      lines = [firstLine, secondLine];
-    }*/
-    return (
-      <text
-        x={x}
-        y={y}
-        textAnchor={textAnchor}
-        fill="var(--color-text)"
-        fontSize={tickFontSize}
-      >
-        {lines.map((line, index) => (
-          <tspan key={index} x={x} dy={index === 0 ? 0 : '1.2em'}>
-            {isMobile ? '' : line}
-          </tspan>
-        ))}
-      </text>
-    );
-  };
-
-  const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
-    if (active && payload && payload.length) {
-      const dataPoint = payload[0].payload;
-      return (
-        <div
-          style={{
-            backgroundColor: 'var(--color-bg)',
-            border: `1px solid var(--border)`,
-            padding: 10,
-            color: 'var(--color-text)',
-          }}
-        >
-          <p>
-            <strong>{label}</strong>
-          </p>
-          <p>
-            {t('importance')}: {dataPoint.importance}
-          </p>
-          <p>
-            {t('lived_according_to_past_week')}: {dataPoint.satisfaction}
-          </p>
-          <p>
-            {t('description')}: {dataPoint.description}
-          </p>
-        </div>
-      );
-    }
-    return null;
-  };
-
   return (
     <div className="bg-[var(--bg)]">
       <ResponsiveContainer
@@ -158,9 +157,9 @@ const RadarChart: React.FC<RadarChartProps> = ({
           <PolarAngleAxis
             dataKey="area"
             tick={
-              renderTick as React.ComponentProps<
-                typeof PolarAngleAxis
-              >['tick']
+              (
+                <RadarTick tickFontSize={tickFontSize} isMobile={isMobile} />
+              ) as React.ComponentProps<typeof PolarAngleAxis>['tick']
             }
           />
           <PolarRadiusAxis
@@ -192,7 +191,7 @@ const RadarChart: React.FC<RadarChartProps> = ({
             strokeLinecap="round"
             strokeLinejoin="round"
           />
-          <Tooltip content={<CustomTooltip />} />
+          <Tooltip content={<RadarTooltip t={t} />} />
           <Legend />
         </RechartsRadarChart>
       </ResponsiveContainer>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -22,9 +22,21 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [theme, setThemeState] = useState<Theme>('light');
-  const [systemTheme, setSystemTheme] = useState<Theme>('light');
-  const [followSystem, setFollowSystemState] = useState<boolean>(false);
+  const getSystemTheme = (): Theme =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+
+  const [systemTheme, setSystemTheme] = useState<Theme>(getSystemTheme);
+  const [followSystem, setFollowSystemState] = useState<boolean>(
+    () => localStorage.getItem('followSystem') === 'true',
+  );
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (localStorage.getItem('followSystem') === 'true') {
+      return getSystemTheme();
+    }
+    return (localStorage.getItem('theme') as Theme) || 'light';
+  });
 
   const setTheme = (theme: Theme) => {
     setThemeState(theme);
@@ -45,21 +57,18 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
     const updateSystemTheme = () => {
       setSystemTheme(media.matches ? 'dark' : 'light');
     };
-    updateSystemTheme();
     media.addEventListener('change', updateSystemTheme);
     return () => media.removeEventListener('change', updateSystemTheme);
   }, []);
 
+  // When following the OS preference, keep the applied theme in sync as that
+  // preference changes mid-session. A deliberate sync with an external system.
   useEffect(() => {
-    const storedTheme = localStorage.getItem('theme') as Theme;
-    const storedFollow = localStorage.getItem('followSystem') === 'true';
-    setFollowSystemState(storedFollow);
-    if (storedFollow) {
+    if (followSystem) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setThemeState(systemTheme);
-    } else if (storedTheme) {
-      setThemeState(storedTheme);
     }
-  }, [systemTheme]);
+  }, [systemTheme, followSystem]);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);

--- a/src/pages/CreateLifeCompass.tsx
+++ b/src/pages/CreateLifeCompass.tsx
@@ -74,9 +74,11 @@ const CreateLifeCompass: React.FC = () => {
   const { dragOverIndex, handleDragStart, handleDragOver, handleDrop, setDragOverIndex } =
     useDragReorder(reorderAreas);
 
-  // Clear editing state if the edited area is no longer in lifeAreas.
+  // Reconcile local editing state with the store: if the edited area is
+  // removed elsewhere (delete, remove-all, import), stop editing it.
   useEffect(() => {
     if (editingAreaId && !lifeAreas.some(area => area.id === editingAreaId)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setEditingAreaId(null);
     }
   }, [lifeAreas, editingAreaId]);


### PR DESCRIPTION
Tackles the dependency held back in #52. Bumps `eslint-plugin-react-hooks` 5 -> 7 and resolves the six violations its new `set-state-in-effect` and `static-components` rules surface -- without behavior change.

## Fixes
- **OnboardingTutorialWrapper, ThemeContext** -- read localStorage / `matchMedia` via lazy `useState` initializers instead of mount-time effects.
- **LanguageSwitcher** -- let i18next's `languageChanged` listener drive state instead of `setState` inside the effect.
- **LifeAreaCard** -- seed the edit draft using React's during-render previous-prop pattern (also removes an extra render commit).
- **RadarChart** -- move the tick and tooltip components to module scope (recharts clones them with its computed props); radar verified rendering via Playwright.
- **CreateLifeCompass / ThemeContext** -- keep one deliberate external-system sync each (store reconciliation; OS theme change) with a justified `eslint-disable`.

## Verified
eslint (0 errors), build, 55 unit tests, 4 chromium E2E, 0 audit findings.

## Still held back (documented, not fixable here)
- **eslint 10** -- `eslint-plugin-react` has no release supporting eslint 10 (every other plugin does); forcing it would break linting.
- **@types/node 25** -- pinned to 22.x to match the Node 22 engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)