### PR TITLE
Fix mobile horizontal overflow (sideways scroll)

### DIFF
--- a/e2e/basicTests.spec.ts
+++ b/e2e/basicTests.spec.ts
@@ -142,4 +142,38 @@ test.describe('Life Compass App End-to-End Tests', () => {
       page.getByRole('checkbox', { name: 'Buy shoes' }),
     ).toBeChecked();
   });
+
+  test('the compass has no horizontal overflow on a narrow viewport', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('tutorialCompleted', 'true');
+    });
+    // 320px is the narrow floor (small phones); guards the header and the
+    // sticky bottom action bar.
+    await page.setViewportSize({ width: 320, height: 780 });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page
+      .getByRole('button', { name: /start your journey/i })
+      .first()
+      .click();
+    await page.waitForLoadState('networkidle');
+    await page.evaluate(() => document.fonts.ready);
+
+    // The compass (incl. the fixed sticky bottom action bar) renders here.
+    // Nothing in the page may extend past the viewport's right edge, or mobile
+    // browsers allow sideways scrolling.
+    const maxRight = await page.evaluate(() => {
+      const vw = document.documentElement.clientWidth;
+      let max = 0;
+      document.querySelectorAll('body *').forEach((el) => {
+        const right = el.getBoundingClientRect().right;
+        if (right > max) max = right;
+      });
+      return Math.round(max - vw);
+    });
+    expect(maxRight).toBeLessThanOrEqual(1);
+  });
 });

--- a/src/components/CompassActionBar.tsx
+++ b/src/components/CompassActionBar.tsx
@@ -92,8 +92,19 @@ const CompassActionBar: React.FC<CompassActionBarProps> = ({
     setMenuOpen(false);
   };
 
-  // Segmented Cards / Radar view toggle.
-  const viewToggle = (
+  // Segmented Cards / Radar view toggle. When `compact`, the segments are
+  // icon-only (with the label moved to aria-label) so the toggle stays narrow
+  // on small screens; the accessible name is unchanged either way.
+  const segClass = (active: boolean) =>
+    cn(
+      'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium',
+      'transition-colors duration-base ease-out-soft',
+      'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus',
+      active
+        ? 'bg-primary text-on-primary'
+        : 'bg-transparent text-text hover:bg-surface-sunken',
+    );
+  const renderViewToggle = (compact: boolean) => (
     <div
       role="group"
       aria-label={t('cards_radar_view')}
@@ -105,17 +116,11 @@ const CompassActionBar: React.FC<CompassActionBarProps> = ({
           if (showRadar) onToggleRadar();
         }}
         aria-pressed={!showRadar}
-        className={cn(
-          'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium',
-          'transition-colors duration-base ease-out-soft',
-          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus',
-          !showRadar
-            ? 'bg-primary text-on-primary'
-            : 'bg-transparent text-text hover:bg-surface-sunken',
-        )}
+        aria-label={compact ? t('view_cards') : undefined}
+        className={segClass(!showRadar)}
       >
         <Squares2X2Icon className="h-5 w-5" aria-hidden="true" />
-        {t('view_cards')}
+        {!compact && t('view_cards')}
       </button>
       <button
         type="button"
@@ -123,30 +128,13 @@ const CompassActionBar: React.FC<CompassActionBarProps> = ({
           if (!showRadar) onToggleRadar();
         }}
         aria-pressed={showRadar}
-        className={cn(
-          'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium',
-          'transition-colors duration-base ease-out-soft',
-          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus',
-          showRadar
-            ? 'bg-primary text-on-primary'
-            : 'bg-transparent text-text hover:bg-surface-sunken',
-        )}
+        aria-label={compact ? t('view_radar') : undefined}
+        className={segClass(showRadar)}
       >
         <ChartPieIcon className="h-5 w-5" aria-hidden="true" />
-        {t('view_radar')}
+        {!compact && t('view_radar')}
       </button>
     </div>
-  );
-
-  const addButton = (
-    <Button
-      variant="primary"
-      onClick={onAddArea}
-      className="shrink-0"
-    >
-      <PlusIcon className="h-5 w-5" aria-hidden="true" />
-      {t('add_life_area')}
-    </Button>
   );
 
   const overflowMenu = (
@@ -192,9 +180,12 @@ const CompassActionBar: React.FC<CompassActionBarProps> = ({
     return (
       <>
         <div className="flex flex-wrap items-center gap-3">
-          {viewToggle}
+          {renderViewToggle(false)}
           <div className="ml-auto flex items-center gap-3">
-            {addButton}
+            <Button variant="primary" onClick={onAddArea} className="shrink-0">
+              <PlusIcon className="h-5 w-5" aria-hidden="true" />
+              {t('add_life_area')}
+            </Button>
             {overflowMenu}
           </div>
         </div>
@@ -203,19 +194,26 @@ const CompassActionBar: React.FC<CompassActionBarProps> = ({
     );
   }
 
-  // Mobile: fixed sticky bottom bar, thumb-reachable, safe-area aware.
+  // Mobile: fixed sticky bottom bar, thumb-reachable, safe-area aware. The
+  // toggle is icon-only and the Add button flexes/truncates so the row always
+  // fits the viewport (no horizontal overflow on narrow screens).
   return (
     <>
       <div
         className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface/95 shadow-warm-md backdrop-blur-sm"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
-        <div className="flex items-center gap-2 px-4 py-2">
-          {viewToggle}
-          <div className="ml-auto flex items-center gap-2">
-            {addButton}
-            {overflowMenu}
-          </div>
+        <div className="flex items-center gap-2 px-3 py-2">
+          {renderViewToggle(true)}
+          <Button
+            variant="primary"
+            onClick={onAddArea}
+            className="min-w-0 flex-1 justify-center"
+          >
+            <PlusIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
+            <span className="truncate">{t('add_life_area')}</span>
+          </Button>
+          {overflowMenu}
         </div>
       </div>
       {ConfirmationDialog}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -91,6 +91,7 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
           data-testid={testId || 'language-switcher'}
           id="language-switcher"
           variant="ghost"
+          size={compact ? 'icon' : 'md'}
           className="flex items-center gap-2 border border-border bg-bg text-text hover:bg-surface-sunken"
         >
           {displayLabel}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/utils';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
 
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -30,6 +30,8 @@ const sizeClasses: Record<ButtonSize, string> = {
   sm: 'min-h-[36px] px-3 py-1.5 text-sm gap-1.5',
   md: 'min-h-[44px] px-4 py-2 text-base gap-2',
   lg: 'min-h-[52px] px-6 py-3 text-lg gap-2',
+  // Square, padding-free target for icon/emoji-only buttons.
+  icon: 'min-h-[44px] min-w-[44px] px-0 py-0 text-base',
 };
 
 const Spinner: React.FC = () => (

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -51,8 +51,11 @@ const HeaderNavigation: React.FC = () => {
   const desktopLinkClass =
     'rounded-md px-2 py-1 text-text-muted no-underline transition-colors duration-base ease-out-soft hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
 
+  // No `display` here on purpose: `cn` is plain clsx (no tailwind-merge), so a
+  // base `inline-flex` would override a responsive `hidden`/`md:hidden`. Each
+  // button sets its own display so the responsive visibility actually applies.
   const iconButtonClass =
-    'inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-transparent bg-transparent text-text transition-colors duration-base ease-out-soft hover:bg-surface-sunken focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
+    'min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-transparent bg-transparent text-text transition-colors duration-base ease-out-soft hover:bg-surface-sunken focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
 
   const mobileLinkClass =
     'block rounded-md px-3 py-3 text-base text-text no-underline transition-colors duration-base ease-out-soft hover:bg-surface-sunken focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
@@ -61,13 +64,13 @@ const HeaderNavigation: React.FC = () => {
     <header className="sticky top-0 z-40 border-b border-border bg-surface/85 backdrop-blur supports-[backdrop-filter]:bg-surface/75">
       <nav
         aria-label={t('primary_navigation', 'Primary')}
-        className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-3"
+        className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-3 py-3 sm:gap-4 sm:px-4"
       >
         {/* Left: wordmark + desktop links */}
-        <div className="flex items-center gap-6">
+        <div className="flex min-w-0 items-center gap-6">
           <Link
             to="/"
-            className="font-display text-xl font-semibold text-primary no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+            className="min-w-0 truncate font-display text-lg font-semibold text-primary no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus sm:text-xl"
           >
             {t('life_compass')}
           </Link>
@@ -87,14 +90,14 @@ const HeaderNavigation: React.FC = () => {
         </div>
 
         {/* Right: language switcher, theme toggle, settings, mobile menu */}
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <LanguageSwitcher compact />
           <button
             type="button"
             onClick={toggleTheme}
             aria-label={t('toggle_theme', 'Toggle light and dark theme')}
             aria-pressed={isDark}
-            className={iconButtonClass}
+            className={`inline-flex ${iconButtonClass}`}
           >
             {isDark ? (
               <SunIcon className="h-6 w-6" />
@@ -113,7 +116,7 @@ const HeaderNavigation: React.FC = () => {
           <button
             ref={toggleButtonRef}
             type="button"
-            className={`md:hidden ${iconButtonClass}`}
+            className={`inline-flex md:hidden ${iconButtonClass}`}
             aria-label={t('toggle_mobile_navigation')}
             aria-expanded={mobileOpen}
             aria-controls="mobile-navigation-menu"


### PR DESCRIPTION
Fixes the sideways-scroll-on-mobile issue reported on GitHub Pages. Two distinct root causes, found by measuring overflowing elements (not guessing):

1. **Mobile sticky bottom action bar** — the Cards/Radar toggle, Add button, and overflow menu were all `shrink-0` with full labels, so their combined width exceeded narrow viewports and pushed the "More" button off-screen. Fixed: icon-only toggle on mobile (labels kept as `aria-label`) + a `flex-1` truncating Add button, so the row always fits.
2. **Header overflowed at <=320px** — the settings icon stayed visible on mobile despite `hidden md:inline-flex`, because `iconButtonClass`'s base `inline-flex` overrode `hidden` (`cn` is plain `clsx`, no tailwind-merge, so conflicting display utilities don't dedupe). Fixed by setting `display` per button. Also added a Button `icon` size for the compact language flag (it was carrying full `md` padding).

## Regression guard
Added a permanent E2E test asserting nothing extends past the viewport on the compass at **320px** (the narrow floor).

## Verified
0 horizontal overflow at 320 / 360 / 390 / 414px on home, compass, and settings. Desktop header unchanged (settings cog + nav links show at >=768px). 6 E2E + 86 unit tests + build + lint, 0 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)