### PR TITLE
Fill in all non-English locales

### DIFF
--- a/public/locales/da/translation.json
+++ b/public/locales/da/translation.json
@@ -75,7 +75,28 @@
       "why_description": "At have klare værdier giver retning og motivation i livet. Uden dem kan vi føle os fortabte eller usikre på vores valg. Med et Livskompas kan du navigere gennem udfordringer, træffe beslutninger og leve mere i overensstemmelse med det, der giver mening for dig.",
       "why_title": "Hvorfor er det vigtigt?"
     },
-    "disclaimer_title": "Vigtigt at vide"
+    "disclaimer_title": "Vigtigt at vide",
+    "disclaimer_description": "Denne app er tænkt som et selvrefleksionsværktøj til at hjælpe dig med at udforske, hvad der er vigtigt i dit liv. Den er ikke ment som erstatning for professionel hjælp, terapi eller kontakt med sundhedsvæsenet. Hvis du har det dårligt eller har brug for støtte, opfordrer vi dig til at søge professionel hjælp.",
+    "examples_description": "En værdi er ikke et mål, men en retning. Eksempler:",
+    "examples_family": "Relationer: \"Jeg vil være en nærværende og omsorgsfuld ven.\"",
+    "examples_health": "Helbred: \"Jeg vil prioritere mit helbred gennem regelmæssig motion og restitution.\"",
+    "examples_title": "Eksempler på værdier",
+    "examples_work": "Arbejde: \"Jeg vil bidrage til noget meningsfuldt og udvikle mig i mit fag.\"",
+    "how_description": "Du reflekterer over forskellige områder af dit liv, såsom:",
+    "how_family": "Familie & relationer: Hvordan vil du være som partner, forælder eller ven?",
+    "how_health": "Helbred & trivsel: Hvordan tager du vare på dig selv fysisk og mentalt?",
+    "how_leisure": "Fritid & personlig udvikling: Hvad giver dig glæde og engagement?",
+    "how_title": "Hvordan fungerer det?",
+    "how_work": "Arbejde & karriere: Hvad er vigtigst for dig i dit arbejde?",
+    "next_steps_description": "Ved at udforske din egen Life Compass kan du begynde at handle i overensstemmelse med dine værdier og skabe et mere meningsfuldt liv. Klik på \"Start din rejse\" for at begynde!",
+    "next_steps_title": "Hvad sker der nu?",
+    "privacy_description": "Vi respekterer dit privatliv. Vi registrerer ingen af dine handlinger eller det, du skriver. Alle dine data forbliver lokale og deles ikke med nogen tredjepart.",
+    "privacy_title": "Privatliv og databeskyttelse",
+    "source_text": "Baseret på materiale fra",
+    "what_is_description": "Life Compass er et værktøj til at reflektere over, hvad der virkelig er vigtigt i dit liv. I stedet for at blive styret af kortsigtede mål eller eksterne forventninger hjælper det dig med at identificere dine kerneværdier -- hvad du står for, og hvordan du vil leve dit liv.",
+    "what_is_title": "Hvad er Life Compass?",
+    "why_description": "Klare værdier giver retning og motivation i livet. Uden dem kan vi føle os fortabte eller usikre i vores beslutninger. Med en Life Compass kan du navigere i udfordringer, træffe beslutninger og leve mere i tråd med det, der er meningsfuldt for dig.",
+    "why_title": "Hvorfor er det vigtigt?"
   },
   "language": "Sprog",
   "life_areas_count": "Antal livsområder",
@@ -99,7 +120,9 @@
     "toolbar_tooltip": "Tag et kig på den flydende verktøjslinje nederst til højre. Den giver dig hurtig adgang til funktioner som at tilføje foruddefinerede livsområder, nulstille, eksportere/importere data og skifte radarvisning.",
     "welcome_prompt": "Velkommen til Livskompas!\nLad os starte introduktionen. Vil du begynde med foruddefinerede livsområder?\n(Du kan altid starte guiden igen fra indstillingsmenuen.)",
     "with_predefined": "Med foruddefinerede livsområder (anbefales)",
-    "without_predefined": "Uden foruddefinerede livsområder"
+    "without_predefined": "Uden foruddefinerede livsområder",
+    "actions": "Brug handlingslinjen til at tilføje livsområder. Skift mellem kort- og radaroversigten med Kort/Radar-knappen, og find øjebliksbilleder, eksport og import under \"Mere\". Dine indstillinger og dit sprog findes i menuen øverst til højre.",
+    "title": "Introduktion"
   },
   "plus_add_new_life_area": "+ Tilføj nyt livsområde",
   "privacyPolicy": {
@@ -171,5 +194,25 @@
   "radar_view_heading": "Dit livskompas i overblik",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "contrast_theme_toggle": "Aktivér højkontrasttema",
+  "goals": {
+    "open_goals": "Mål",
+    "dialog_title": "Mål for {{area}}",
+    "dialog_description": "Sæt mål for dette livsområde, og del dem op i handlingstrin.",
+    "add_goal": "Tilføj mål",
+    "add_goal_placeholder": "Hvad vil du opnå?",
+    "empty_state": "Ingen mål endnu. Tilføj dit første mål for at omsætte dette område til handling.",
+    "goal_title": "Målets titel",
+    "expand_goal": "Vis trin",
+    "collapse_goal": "Skjul trin",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Fremskridt for {{title}}",
+    "delete_goal_title": "Slet mål",
+    "delete_goal_warning": "Dette sletter målet \"{{title}}\" og alle dets trin. Vil du fortsætte?",
+    "add_step": "Tilføj trin",
+    "add_step_placeholder": "Tilføj et handlingstrin",
+    "delete_step": "Slet trin"
+  },
+  "lived_according_to_past_week": "Levet efter i den forgangne uge"
 }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -75,7 +75,28 @@
       "why_description": "Klare Werte geben im Leben Richtung und Motivation. Ohne sie fühlen wir uns möglicherweise verloren oder unsicher bei unseren Entscheidungen. Mit einem Lebenskompass können Sie Herausforderungen meistern, Entscheidungen treffen und mehr im Einklang mit dem leben, was Ihnen wirklich wichtig ist.",
       "why_title": "Warum ist es wichtig?"
     },
-    "disclaimer_title": "Wichtig zu wissen"
+    "disclaimer_title": "Wichtig zu wissen",
+    "disclaimer_description": "Diese App ist als Werkzeug zur Selbstreflexion gedacht und soll dir helfen, herauszufinden, was dir in deinem Leben wichtig ist. Sie ersetzt keine professionelle Hilfe, Therapie oder den Kontakt zum Gesundheitswesen. Wenn es dir nicht gut geht oder du Unterstützung benötigst, empfehlen wir dir, professionelle Hilfe in Anspruch zu nehmen.",
+    "examples_description": "Ein Wert ist kein Ziel, sondern eine Richtung. Beispiele:",
+    "examples_family": "Beziehungen: \"Ich möchte eine aufmerksame und fürsorgliche Freundin / ein aufmerksamer und fürsorglicher Freund sein.\"",
+    "examples_health": "Gesundheit: \"Ich möchte meine Gesundheit durch regelmäßige Bewegung und Erholung in den Vordergrund stellen.\"",
+    "examples_title": "Beispiele für Werte",
+    "examples_work": "Arbeit: \"Ich möchte zu etwas Bedeutungsvollem beitragen und mich in meinem Beruf weiterentwickeln.\"",
+    "how_description": "Du reflektierst verschiedene Lebensbereiche, zum Beispiel:",
+    "how_family": "Familie & Beziehungen: Wie möchtest du als Partner, Elternteil oder Freund sein?",
+    "how_health": "Gesundheit & Wohlbefinden: Wie sorgst du körperlich und geistig für dich?",
+    "how_leisure": "Freizeit & persönliche Entwicklung: Was macht dich glücklich und erfüllt?",
+    "how_title": "Wie funktioniert es?",
+    "how_work": "Arbeit & Karriere: Was ist dir bei deiner Arbeit am wichtigsten?",
+    "next_steps_description": "Indem du deinen eigenen Life Compass erkundest, kannst du anfangen, gemäß deinen Werten zu handeln und ein erfüllteres Leben zu gestalten. Klicke auf \"Deine Reise beginnen\", um loszulegen!",
+    "next_steps_title": "Was passiert als Nächstes?",
+    "privacy_description": "Wir respektieren deine Privatsphäre. Wir erfassen weder deine Aktionen noch das, was du schreibst. Alle deine Daten bleiben lokal gespeichert und werden nicht an Dritte weitergegeben.",
+    "privacy_title": "Datenschutz",
+    "source_text": "Basierend auf Material von",
+    "what_is_description": "Life Compass ist ein Werkzeug, um darüber nachzudenken, was wirklich wichtig in deinem Leben ist. Anstatt von kurzfristigen Zielen oder äußeren Erwartungen geleitet zu werden, hilft es dir, deine Kernwerte zu erkennen -- wofür du stehst und wie du dein Leben gestalten möchtest.",
+    "what_is_title": "Was ist der Life Compass?",
+    "why_description": "Klare Werte geben Richtung und Motivation im Leben. Ohne sie können wir uns bei Entscheidungen verloren oder unsicher fühlen. Mit einem Life Compass kannst du Herausforderungen meistern, Entscheidungen treffen und mehr im Einklang mit dem leben, was dir wichtig ist.",
+    "why_title": "Warum ist das wichtig?"
   },
   "language": "Sprache",
   "life_areas_count": "Anzahl der Lebensbereiche",
@@ -99,7 +120,9 @@
     "toolbar_tooltip": "Schauen Sie sich die schwebende Symbolleiste unten rechts an. Sie bietet Ihnen schnellen Zugriff auf Aktionen wie das Hinzufügen vordefinierter Lebensbereiche, das Zurücksetzen, Exportieren/Importieren von Daten und das Umschalten der Radaranzeige.",
     "welcome_prompt": "Willkommen bei Lebenskompass!\nLassen Sie uns mit der Einführung beginnen. Möchten Sie mit vordefinierten Lebensbereichen starten?\n(Sie können die Anleitung jederzeit über das Einstellungsmenü erneut starten.)",
     "with_predefined": "Mit vordefinierten Lebensbereichen (empfohlen)",
-    "without_predefined": "Ohne vordefinierte Lebensbereiche"
+    "without_predefined": "Ohne vordefinierte Lebensbereiche",
+    "actions": "Nutze die Aktionsleiste, um Lebensbereiche hinzuzufügen. Wechsle mit dem Karten-/Radar-Schalter zwischen der Kartenansicht und der Radarübersicht, und finde Momentaufnahmen, Export und Import unter \"Mehr\". Deine Einstellungen und Sprache findest du im Menü oben rechts.",
+    "title": "Einführung"
   },
   "plus_add_new_life_area": "+ Neuen Lebensbereich hinzufügen",
   "privacyPolicy": {
@@ -171,5 +194,28 @@
   "radar_view_heading": "Dein Lebenskompass im Überblick",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "accessibility_settings": "Barrierefreiheitseinstellungen",
+  "contrast_theme_toggle": "Hochkontrastmodus aktivieren",
+  "goals": {
+    "open_goals": "Ziele",
+    "dialog_title": "Ziele für {{area}}",
+    "dialog_description": "Lege Ziele für diesen Lebensbereich fest und unterteile sie in konkrete Schritte.",
+    "add_goal": "Ziel hinzufügen",
+    "add_goal_placeholder": "Was möchtest du erreichen?",
+    "empty_state": "Noch keine Ziele. Füge dein erstes Ziel hinzu, um diesen Bereich in die Tat umzusetzen.",
+    "goal_title": "Zieltitel",
+    "expand_goal": "Schritte anzeigen",
+    "collapse_goal": "Schritte ausblenden",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Fortschritt für {{title}}",
+    "delete_goal_title": "Ziel löschen",
+    "delete_goal_warning": "Das Ziel \"{{title}}\" und alle zugehörigen Schritte werden gelöscht. Möchtest du fortfahren?",
+    "add_step": "Schritt hinzufügen",
+    "add_step_placeholder": "Handlungsschritt hinzufügen",
+    "delete_step": "Schritt löschen"
+  },
+  "lived_according_to_past_week": "Gelebt gemäß der letzten Woche",
+  "start_your_journey": "Deine Reise beginnen",
+  "theme_system": "System"
 }

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -108,7 +108,10 @@
     "toolbar_tooltip": "Katso kelluva työkalupalkki oikeassa alakulmassa. Sieltä saat pikalinkin toimintoihin, kuten esiasetettujen elämänalueiden lisäämiseen, palauttamiseen, tietojen vientiin/tuontiin ja tutkanäkymän vaihtamiseen.",
     "welcome_prompt": "Tervetuloa Elämänkompassiin!\nAloitetaan opastus. Haluatko aloittaa esiasetetuilla elämänalueilla?\n(Voit suorittaa oppaan uudelleen asetuksista.)",
     "with_predefined": "Esiasetettujen elämänalueiden kanssa (suositellaan)",
-    "without_predefined": "Ilman esiasetettuja elämänalueita"
+    "without_predefined": "Ilman esiasetettuja elämänalueita",
+    "privacy_notice": "Yksityisyytesi on meille tärkeä. Toimintojasi tai syötteitäsi ei seurata; kaikki tiedot pysyvät laitteellasi.",
+    "actions": "Lisää elämänalueita toimintopalkin avulla. Vaihda korttinäkymän ja tutkanäkymän välillä Kortit / Tutka -valitsimella, ja löydät tilannekuvat, viennin ja tuonnin kohdasta \"Lisää\". Asetukset ja kieli löytyvät oikeasta yläkulmasta.",
+    "title": "Johdanto"
   },
   "plus_add_new_life_area": "+ Lisää uusi elämänalue",
   "privacyPolicy": {
@@ -181,5 +184,26 @@
   "radar_view_heading": "Elämänkompassisi yhdellä silmäyksellä",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "accessibility_settings": "Saavutettavuusasetukset",
+  "contrast_theme_toggle": "Ota käyttöön korkean kontrastin teema",
+  "goals": {
+    "open_goals": "Tavoitteet",
+    "dialog_title": "Tavoitteet: {{area}}",
+    "dialog_description": "Aseta tavoitteet tälle elämänalueelle ja jaa ne toimintavaiheisiin.",
+    "add_goal": "Lisää tavoite",
+    "add_goal_placeholder": "Mitä haluat saavuttaa?",
+    "empty_state": "Ei vielä tavoitteita. Lisää ensimmäinen tavoitteesi ja muuta tämä alue teoiksi.",
+    "goal_title": "Tavoitteen nimi",
+    "expand_goal": "Näytä vaiheet",
+    "collapse_goal": "Piilota vaiheet",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Edistyminen: {{title}}",
+    "delete_goal_title": "Poista tavoite",
+    "delete_goal_warning": "Tämä poistaa tavoitteen \"{{title}}\" ja kaikki sen vaiheet. Haluatko jatkaa?",
+    "add_step": "Lisää vaihe",
+    "add_step_placeholder": "Lisää toimintavaihe",
+    "delete_step": "Poista vaihe"
+  },
+  "theme_system": "Järjestelmä"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -108,7 +108,10 @@
     "toolbar_tooltip": "Regardez la barre d'outils flottante en bas à droite. Vous y accédez rapidement aux fonctionnalités telles que l'ajout de domaines prédéfinis, la réinitialisation, l'exportation/importation des données et le changement entre la vue carte et la vue radar.",
     "welcome_prompt": "Bienvenue à la boussole de vie !\nCommençons l'introduction. Voulez-vous démarrer avec des domaines prédéfinis ?\n(Vous pouvez toujours relancer l'introduction via le menu des paramètres.)",
     "with_predefined": "Avec des domaines prédéfinis (recommandé)",
-    "without_predefined": "Sans domaines prédéfinis"
+    "without_predefined": "Sans domaines prédéfinis",
+    "privacy_notice": "Nous respectons votre vie privée. Aucune de vos actions ou saisies n'est suivie ; toutes les données restent sur votre appareil.",
+    "actions": "Utilisez la barre d'actions pour ajouter des domaines de vie. Basculez entre les cartes et la vue radar avec le bouton Cartes / Radar, et accédez aux instantanés, à l'export et à l'import via \"Plus\". Vos paramètres et la langue se trouvent dans le menu en haut à droite.",
+    "title": "Introduction"
   },
   "plus_add_new_life_area": "+ Ajouter un nouveau domaine de vie",
   "privacyPolicy": {
@@ -181,5 +184,25 @@
   "radar_view_heading": "Votre boussole de vie en un coup d œil",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "contrast_theme_toggle": "Activer le thème à contraste élevé",
+  "goals": {
+    "open_goals": "Objectifs",
+    "dialog_title": "Objectifs pour {{area}}",
+    "dialog_description": "Définissez des objectifs pour ce domaine de vie et décomposez-les en étapes concrètes.",
+    "add_goal": "Ajouter un objectif",
+    "add_goal_placeholder": "Qu'est-ce que vous souhaitez accomplir ?",
+    "empty_state": "Aucun objectif pour l'instant. Ajoutez votre premier objectif pour commencer à agir dans ce domaine.",
+    "goal_title": "Titre de l'objectif",
+    "expand_goal": "Afficher les étapes",
+    "collapse_goal": "Masquer les étapes",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Progression pour {{title}}",
+    "delete_goal_title": "Supprimer l'objectif",
+    "delete_goal_warning": "Cela supprimera l'objectif \"{{title}}\" et toutes ses étapes. Voulez-vous continuer ?",
+    "add_step": "Ajouter une étape",
+    "add_step_placeholder": "Ajouter une étape d'action",
+    "delete_step": "Supprimer l'étape"
+  },
+  "theme_system": "Système"
 }

--- a/public/locales/is/translation.json
+++ b/public/locales/is/translation.json
@@ -107,7 +107,10 @@
     "toolbar_tooltip": "Skoðaðu flottu verkfærabeltuna neðst til hægri. Þar færðu aðgang að fyrirfram skilgreindum sviðum, endurstillingum, útflutnings- og innflutningsgögnum og möguleika á að skipta milli kortsýningar og radar-sýnar.",
     "welcome_prompt": "Velkominn/nn í Lífsáttavituna!\nHefjum upphafsleiðbeininguna. Viltu byrja með fyrirfram skilgreindum sviðum?\n(Þú getur alltaf endurlesið leiðbeiningarnar í stillingavalmyndinni.)",
     "with_predefined": "Með fyrirfram skilgreindum sviðum (mælt með)",
-    "without_predefined": "Án fyrirfram skilgreinda sviða"
+    "without_predefined": "Án fyrirfram skilgreinda sviða",
+    "privacy_notice": "Við virðum friðhelgi þína. Engar aðgerðir þínar eða innsláttur eru raktar; öll gögn eru geymd á tækinu þínu.",
+    "actions": "Notaðu aðgerðarstikuna til að bæta við lífsvæðum. Skiptu á milli korta og ratsjáryfirlit með Kort / Ratsjá rofanum, og finndu skyndimyndir, útflutning og innflutning undir \"Meira\". Stillingar þínar og tungumál eru í valmyndinni efst til hægri.",
+    "title": "Kynning"
   },
   "plus_add_new_life_area": "+ Bæta við nýju sviði lífsins",
   "privacyPolicy": {
@@ -180,5 +183,26 @@
   "radar_view_heading": "Lífsáttavitinn þinn í yfirliti",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "contrast_theme_toggle": "Virkja háskýrleika þema",
+  "goals": {
+    "open_goals": "Markmið",
+    "dialog_title": "Markmið fyrir {{area}}",
+    "dialog_description": "Settu markmið fyrir þetta lífsvæði og skiptu þeim upp í aðgerðarskref.",
+    "add_goal": "Bæta við markmiði",
+    "add_goal_placeholder": "Hvað viltu ná fram?",
+    "empty_state": "Engin markmið enn. Bættu við fyrsta markmiðinu til að byrja að breyta þessu svæði í aðgerðir.",
+    "goal_title": "Heiti markmiðs",
+    "expand_goal": "Sýna skref",
+    "collapse_goal": "Fela skref",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Framfarir fyrir {{title}}",
+    "delete_goal_title": "Eyða markmiði",
+    "delete_goal_warning": "Þetta mun eyða markmiðinu \"{{title}}\" og öllum skrefum þess. Viltu halda áfram?",
+    "add_step": "Bæta við skrefi",
+    "add_step_placeholder": "Bættu við aðgerðarskrefi",
+    "delete_step": "Eyða skrefi"
+  },
+  "name_is_required": "Nafn er nauðsynlegt",
+  "theme_system": "Kerfi"
 }

--- a/public/locales/nb/translation.json
+++ b/public/locales/nb/translation.json
@@ -74,7 +74,28 @@
       "why_description": "Å ha klare verdier gir retning og motivasjon i livet. Uten disse kan vi føle oss fortapt eller usikre på valgene våre. Med et Livskompass kan du navigere utfordringer, ta beslutninger og leve mer i tråd med det som er meningsfullt for deg.",
       "why_title": "Hvorfor er det viktig?"
     },
-    "disclaimer_title": "Viktig å vite"
+    "disclaimer_title": "Viktig å vite",
+    "disclaimer_description": "Denne appen er ment som et selvrefleksjonsverktøy som hjelper deg å utforske hva som er viktig i livet ditt. Den er ikke ment å erstatte profesjonell hjelp, terapi eller kontakt med helsevesenet. Hvis du har det vanskelig eller trenger støtte, oppfordrer vi deg til å oppsøke profesjonell hjelp.",
+    "examples_description": "En verdi er ikke et mål, men en retning. Eksempler:",
+    "examples_family": "Relasjoner: \"Jeg vil være en tilstedeværende og omsorgsfull venn.\"",
+    "examples_health": "Helse: \"Jeg vil prioritere helsen min gjennom regelmessig trening og restitusjon.\"",
+    "examples_title": "Eksempler på verdier",
+    "examples_work": "Arbeid: \"Jeg vil bidra med noe meningsfullt og utvikle meg i faget mitt.\"",
+    "how_description": "Du reflekterer over ulike områder i livet ditt, for eksempel:",
+    "how_family": "Familie & relasjoner: Hvordan vil du være som partner, forelder eller venn?",
+    "how_health": "Helse & velvære: Hvordan tar du vare på deg selv fysisk og mentalt?",
+    "how_leisure": "Fritid & personlig utvikling: Hva gjør deg glad og engasjert?",
+    "how_title": "Hvordan fungerer det?",
+    "how_work": "Arbeid & karriere: Hva er viktigst for deg i arbeidet ditt?",
+    "next_steps_description": "Ved å utforske din egen Life Compass kan du begynne å handle i tråd med verdiene dine og skape et mer meningsfullt liv. Klikk på \"Start reisen din\" for å begynne!",
+    "next_steps_title": "Hva skjer videre?",
+    "privacy_description": "Vi respekterer personvernet ditt. Vi sporer ingen av handlingene dine eller det du skriver. Alle data lagres lokalt og deles ikke med noen ekstern part.",
+    "privacy_title": "Personvern og databeskyttelse",
+    "source_text": "Basert på materiale fra",
+    "what_is_description": "Life Compass er et verktøy for å reflektere over hva som virkelig er viktig i livet ditt. I stedet for å styres av kortsiktige mål eller ytre forventninger, hjelper det deg å identifisere dine kjerneverdier -- hva du står for og hvordan du vil leve livet ditt.",
+    "what_is_title": "Hva er Life Compass?",
+    "why_description": "Klare verdier gir retning og motivasjon i livet. Uten dem kan vi føle oss lost eller usikre i beslutningene våre. Med en Life Compass kan du navigere utfordringer, ta beslutninger og leve mer i tråd med det som er meningsfullt for deg.",
+    "why_title": "Hvorfor er det viktig?"
   },
   "language": "Språk",
   "life_areas_count": "Antall livsområder",
@@ -99,7 +120,9 @@
     "toolbar_tooltip": "Ta en titt på den flytende verktøylinjen nede til høyre. Den gir deg rask tilgang til handlinger som å legge til forhåndsdefinerte livsområder, tilbakestille, eksportere/importere data og bytte radarskjerm.",
     "welcome_prompt": "Velkommen til Livskompass!\nLa oss starte introduksjonen. Vil du begynne med forhåndsdefinerte livsområder?\n(Du kan alltid starte om introduksjonen fra innstillingsmenyen.)",
     "with_predefined": "Med forhåndsdefinerte livsområder (anbefales)",
-    "without_predefined": "Uten forhåndsdefinerte livsområder"
+    "without_predefined": "Uten forhåndsdefinerte livsområder",
+    "actions": "Bruk handlingslinjen til å legge til livsområder. Bytt mellom kortvisning og radaroversikt med Kort / Radar-bryteren, og finn øyeblikksbilder, eksport og import under \"Mer\". Innstillinger og språk finner du i menyen øverst til høyre.",
+    "title": "Introduksjon"
   },
   "plus_add_new_life_area": "+ Legg til nytt livsområde",
   "privacyPolicy": {
@@ -176,5 +199,25 @@
   "radar_view_heading": "Livskompasset ditt i oversikt",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "choose_theme": "Velg tema",
+  "contrast_theme_toggle": "Aktiver høykontrasttema",
+  "goals": {
+    "open_goals": "Mål",
+    "dialog_title": "Mål for {{area}}",
+    "dialog_description": "Sett mål for dette livsområdet og del dem opp i handlingssteg.",
+    "add_goal": "Legg til mål",
+    "add_goal_placeholder": "Hva ønsker du å oppnå?",
+    "empty_state": "Ingen mål ennå. Legg til ditt første mål for å begynne å omsette dette området til handling.",
+    "goal_title": "Måltittel",
+    "expand_goal": "Vis steg",
+    "collapse_goal": "Skjul steg",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Fremgang for {{title}}",
+    "delete_goal_title": "Slett mål",
+    "delete_goal_warning": "Dette vil slette målet \"{{title}}\" og alle tilhørende steg. Vil du fortsette?",
+    "add_step": "Legg til steg",
+    "add_step_placeholder": "Legg til et handlingssteg",
+    "delete_step": "Slett steg"
+  }
 }

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -96,7 +96,9 @@
     "toolbar_tooltip": "Bekijk de zwevende werkbalk rechtsonder. Hiermee krijg je snelle toegang tot functies zoals het toevoegen van vooraf gedefinieerde levensgebieden, resetten, exporteren/importeren van gegevens en het wisselen van de radarweergave.",
     "welcome_prompt": "Welkom bij Levenskompas!\nLaten we de introductie beginnen. Wil je starten met vooraf gedefinieerde levensgebieden?\n(U kunt de introductie altijd opnieuw starten via het instellingenmenu.)",
     "with_predefined": "Met voordefinieerde levensgebieden (aanbevolen)",
-    "without_predefined": "Zonder voordefinieerde levensgebieden"
+    "without_predefined": "Zonder voordefinieerde levensgebieden",
+    "actions": "Gebruik de actiebalk om levensgebieden toe te voegen. Schakel tussen de kaarten en het radaroverzicht met de schakelaar Kaarten / Radar, en vind momentopnames, exporteren en importeren onder 'Meer'. Je instellingen en taal staan in het menu rechtsboven.",
+    "title": "Introductie"
   },
   "plus_add_new_life_area": "+ Nieuw levensgebied toevoegen",
   "privacyPolicy": {
@@ -169,5 +171,27 @@
   "radar_view_heading": "Jouw levenskompas in één oogopslag",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "contrast_theme_toggle": "Hoog-contrastthema inschakelen",
+  "goals": {
+    "open_goals": "Doelen",
+    "dialog_title": "Doelen voor {{area}}",
+    "dialog_description": "Stel doelen in voor dit levensgebied en verdeel ze in actiestappen.",
+    "add_goal": "Doel toevoegen",
+    "add_goal_placeholder": "Wat wil je bereiken?",
+    "empty_state": "Nog geen doelen. Voeg je eerste doel toe om dit gebied in actie te zetten.",
+    "goal_title": "Doelomschrijving",
+    "expand_goal": "Stappen tonen",
+    "collapse_goal": "Stappen verbergen",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "Voortgang voor {{title}}",
+    "delete_goal_title": "Doel verwijderen",
+    "delete_goal_warning": "Dit verwijdert het doel \"{{title}}\" en alle bijbehorende stappen. Wil je doorgaan?",
+    "add_step": "Stap toevoegen",
+    "add_step_placeholder": "Voeg een actiestap toe",
+    "delete_step": "Stap verwijderen"
+  },
+  "lived_according_to_past_week": "Nageleefd de afgelopen week",
+  "start_your_journey": "Begin je reis",
+  "theme_system": "Systeem"
 }

--- a/public/locales/tlh/translation.json
+++ b/public/locales/tlh/translation.json
@@ -65,7 +65,14 @@
     "how_title": "chay yIlo'?",
     "how_work": "SuvwI' Qapla', Heghmey nuch yIjatlh.",
     "next_steps_description": "Hurghmey yInobpu'. yItlhutlh 'ej Qapla' lo'vam yIghoS.",
-    "next_steps_title": "chay DaQuch?"
+    "next_steps_title": "chay DaQuch?",
+    "privacy_description": "We respect your privacy. We do not track any of your actions or what you write. All your data remains local and is not shared with any external party.",
+    "privacy_title": "pegh Data je",
+    "source_text": "ngan'e' Dalo'ta'",
+    "what_is_description": "Life Compass yIn Dalo'meH jan. tugh ngoQmey pIm 'ej reH chaw'be' ngoQmey -- DIS qawHaqDaj tIchel 'ej yInlIj yIbuSqa'.",
+    "what_is_title": "Life Compass nuq?",
+    "why_description": "vIHtaH ngoQmeyraj DarurmeH, DIvI' DaSuqlaH. 'ach ngoQmey Dachaw'be'chugh, bIQoSlaHbe'. Life Compass Dalo'chugh, Hegh DuHaD 'ej Dochmey DanIDlaH.",
+    "why_title": "qatlh potlh?"
   },
   "language": "Hol",
   "life_areas_count": "Hurghmey",
@@ -101,7 +108,10 @@
     "toolbar_tooltip": "Hurghmey Qapla' yIlo'.",
     "welcome_prompt": "Qapla'! loSDI' Hurghmey Dap. (vaj Qapla' yInobpu')",
     "with_predefined": "Hurghmey chu' (batlh je Qapla')",
-    "without_predefined": "Hurghmey QaQ"
+    "without_predefined": "Hurghmey QaQ",
+    "privacy_notice": "peghraj DatIvmoH. vangmeylIj ghItlhlIj joq wIqawbe'. Hoch DataDaj pa'DajlIjDaq 'oHtaH.",
+    "actions": "yIn Daq chu' yIchel -- vangmeH boq yIDalo'. \"QIn / QIn'a'\" choHwI' Dalo'taHvIS HIDjolev Quj legh. \"latlh\" bIngDaq, chenmoHta'bogh DataDaj, HolQeD, je bIQDaq Data' DaghItlhlaH. naSvaD ghojmoHmeH pat latlh Hap Saj chevwI'Daq tu'lu'.",
+    "title": "ngoQmey ngu'"
   },
   "plus_add_new_life_area": "+ Hurghmey",
   "privacyPolicy": {
@@ -115,7 +125,9 @@
     "noCookiesTitle": "cookie Sovbe'",
     "noTracking": "tracking Qapla'be'. qaStaHvIS mIw, tracking Sovbe'.",
     "noTrackingTitle": "Sovbe' tracking",
-    "title": "batlh data"
+    "title": "batlh data",
+    "userControl": "You have full control over your data. It is stored securely on your device, and you can export or remove it at any time by clearing your browser's local storage.",
+    "userControlTitle": "lo'wI' SeH"
   },
   "quick_actions": "Qapla' Qu'",
   "radar_view": "radar mIw",
@@ -172,5 +184,25 @@
   "radar_view_heading": "Your life compass at a glance",
   "settings_appearance": "Appearance",
   "settings_language": "Language",
-  "settings_data": "Data"
+  "settings_data": "Data",
+  "contrast_theme_toggle": "ghurmoH wovqu' qoH",
+  "goals": {
+    "open_goals": "ngoQmey",
+    "dialog_title": "{{area}} ngoQmey",
+    "dialog_description": "yInDaq ngoQmey tIchel. ngoQmey tIbuS 'ej laSvarghmeychajDaq tIghor.",
+    "add_goal": "ngoQ yIchel",
+    "add_goal_placeholder": "nuq DaSuqqang?",
+    "empty_state": "ngoQmey tu'lu'be'. wa'DIch ngoQ yIchel. reH ngoQ vIghro'vo' vItaghmoH.",
+    "goal_title": "ngoQ pong",
+    "expand_goal": "HeSmey yIlegh",
+    "collapse_goal": "HeSmey tIpoSmoH",
+    "progress_count": "{{done}}/{{total}}",
+    "progress_label": "{{title}} cha'bogh HoS",
+    "delete_goal_title": "ngoQ yIlel",
+    "delete_goal_warning": "\"{{title}}\" ngoQ HeSmeyraj je lIllaH. yIpISchoH?",
+    "add_step": "HeS yIchel",
+    "add_step_placeholder": "vangmeH HeS yIchel",
+    "delete_step": "HeS yIlel"
+  },
+  "theme_system": "pat"
 }


### PR DESCRIPTION
Every non-English locale was missing keys (the goals feature, the onboarding update, the home introduction content, and theme/accessibility keys) and silently fell back to English. This translates all of them.

## How
One translator agent per locale (da, de, fi, fr, is, nb, nl, tlh), each translating exactly the keys missing versus English. Merged deterministically (Python deep-set), then formatted.

## Result
- **Every locale now has zero missing keys** relative to English.
- i18next placeholders (`{{area}}`, `{{title}}`, `{{done}}`, `{{total}}`, ...) preserved exactly.
- **Native orthography**: a first pass ASCII-stripped some diacritics (German "fur", Finnish/French/Norwegian missing accents); re-translated those locales with native spelling enforced (umlauts, accents, æ/ø/å, þ/ð, etc.). Validated that each locale carries its expected diacritics.
- Klingon (tlh) uses honest English fallbacks where confident Klingon wasn't possible.

## Verified
86 unit tests (incl. translation-loader), build, lint. German render spot-checked (home + introduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)